### PR TITLE
Enhancements in JNIEnv#throw_new() 

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -229,10 +229,10 @@ impl<'a> JNIEnv<'a> {
     {
         let throwable = obj.lookup(self)?;
         let res: i32 = jni_unchecked!(self.internal, Throw, throwable.into_inner());
-        if res < 0 {
-            Err(format!("throw failed with code {}", res).into())
-        } else {
+        if res == 0 {
             Ok(())
+        } else {
+            Err(format!("throw failed with code {}", res).into())
         }
     }
 
@@ -251,10 +251,10 @@ impl<'a> JNIEnv<'a> {
         let class = class.lookup(self)?;
         let msg = msg.into();
         let res: i32 = jni_unchecked!(self.internal, ThrowNew, class.into_inner(), msg.as_ptr());
-        if res < 0 {
-            Err(format!("throw_new failed with code {}", res).into())
-        } else {
+        if res == 0 {
             Ok(())
+        } else {
+            Err(format!("throw_new failed with code {}", res).into())
         }
     }
 

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -458,16 +458,17 @@ pub fn throw_new() {
 
     let result = env.throw_new("java/lang/RuntimeException", "Test Exception");
     assert!(result.is_ok());
-    let ex = env
+    let ex: JObject = env
         .exception_occurred()
-        .expect("Exception should be thrown");
+        .expect("Exception should be thrown")
+        .into();
     assert_pending_java_exception(&env);
 
     assert!(env
-        .is_instance_of(ex.clone().into(), "java/lang/RuntimeException")
+        .is_instance_of(ex, "java/lang/RuntimeException")
         .unwrap());
     let message = env
-        .call_method(ex.into(), "getMessage", "()Ljava/lang/String;", &[])
+        .call_method(ex, "getMessage", "()Ljava/lang/String;", &[])
         .unwrap()
         .l()
         .unwrap();


### PR DESCRIPTION
## Overview

This is a supplementary PR to enhance the abandoned #157. It contains implemented review suggestions.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
